### PR TITLE
Fix code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "^4.21.0",
     "killable": "^1.0.1",
     "socket.io": "^4.7.0",
-    "twilio": "^4.19.3"
+    "twilio": "^4.19.3",
+    "express-rate-limit": "^7.4.0"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/EmulatorJS/EmulatorJS-netplay-old/security/code-scanning/5](https://github.com/EmulatorJS/EmulatorJS-netplay-old/security/code-scanning/5)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will involve:
1. Installing the `express-rate-limit` package.
2. Importing the package in the `index.js` file.
3. Setting up a rate limiter with appropriate configuration.
4. Applying the rate limiter to the routes that perform sensitive operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
